### PR TITLE
Update cloudbeat-ci.yml

### DIFF
--- a/.github/workflows/Periodic-CI.yml
+++ b/.github/workflows/Periodic-CI.yml
@@ -172,6 +172,8 @@ jobs:
         id: install
 
       - uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.2.0

--- a/.github/workflows/cloudbeat-ci.yml
+++ b/.github/workflows/cloudbeat-ci.yml
@@ -201,6 +201,8 @@ jobs:
         id: install
 
       - uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.2.0


### PR DESCRIPTION
updates extractions/setup-just@v1 action to use `GITHUB_TOKEN` in order to avoid [rate-limiting errors](https://github.com/elastic/cloudbeat/actions/runs/3078654006/jobs/4974428235#step:4:6) like here:
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/85433724/190929185-77fa0ecd-67ac-4a5a-a12e-e9747b4a0ad5.png">

